### PR TITLE
Reduce incomes chart height

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -281,7 +281,7 @@
       {{ _("In addition, YunoHost receives significant in-kind donations in the form of servers or bandwidth from other non-profit organizations as well as from independent web companies such as Globenet, Gitoyen, TetaNeutral and Octopuce.<br>These in-kind donations are not represented in the graph below.") }}
     </p>
 
-    <div style="height: 60vh;" class="my-5 p-5 pt-2">
+    <div style="height: 40vh;" class="my-5 p-5 pt-2">
         <canvas id="recettes" aria-hidden="true"></canvas>
     </div>
 


### PR DESCRIPTION
I find `60vh` to be huge, let's reduce to `40vh`.😅

![image](https://github.com/user-attachments/assets/28ea02f3-75aa-4232-9f12-06e3285f8fbe)
