### PR TITLE
Add Mastodon verification tag

### DIFF
--- a/base.html
+++ b/base.html
@@ -199,7 +199,7 @@
                     <ul>
                         {# <li><a href="">{{ _('Press kit') }}</a></li> #}
                         <li class="pb-2"><a class="hover:opacity-75" href="https://forum.yunohost.org/c/announcement/8/none">{{ _('Blog') }}</a></li>
-                        <li class="pb-2"><a class="hover:opacity-75" href="https://toot.aquilenet.fr/@yunohost">{{ _('Mastodon') }}</a></li>
+                        <li class="pb-2"><a class="hover:opacity-75" href="https://toot.aquilenet.fr/@yunohost" rel="me">{{ _('Mastodon') }}</a></li>
                         <li class="pb-2"><a class="hover:opacity-75" href="https://videos.globenet.org/a/yunohost/videos?s=1">{{ _('Peertube') }}</a></li>
                         {# <li class="pb-2"><a href="">{{ _('RSS feed') }}</a></li> #}
                     </ul>


### PR DESCRIPTION
cf. https://joinmastodon.org/verification
It was initially on the website, but got forgotten in the remake.